### PR TITLE
actually use scope for `canBeDefault`

### DIFF
--- a/Sources/CAAudioHardware/AudioDevice.swift
+++ b/Sources/CAAudioHardware/AudioDevice.swift
@@ -132,7 +132,7 @@ extension AudioDevice {
 	/// - remark: This corresponds to the property `kAudioDevicePropertyDeviceCanBeDefaultDevice`
 	/// - parameter scope: The desired scope
 	public func canBeDefault(inScope scope: PropertyScope) throws -> Bool {
-		return try getProperty(PropertyAddress(kAudioDevicePropertyDeviceCanBeDefaultDevice), type: UInt32.self) != 0
+		return try getProperty(PropertyAddress(PropertySelector(kAudioDevicePropertyDeviceCanBeDefaultDevice), scope: scope), type: UInt32.self) != 0
 	}
 
 	/// Returns `true` if the device can be the system default device


### PR DESCRIPTION
This is a minor bug fix. It looks like the `canBeDefault` method wasn't using the scope that was being passed in. The property doesn't exist on the global scope, so the function always failed.