### PR TITLE
Relax preconditions on `kAudioObjectUnknown`

### DIFF
--- a/Sources/CAAudioHardware/AudioControl.swift
+++ b/Sources/CAAudioHardware/AudioControl.swift
@@ -74,8 +74,11 @@ extension AudioObjectSelector where T == AudioControl {
 
 /// Creates and returns an initialized `AudioControl` or subclass.
 func makeAudioControl(_ objectID: AudioObjectID, baseClass: AudioClassID /*= kAudioControlClassID*/) throws -> AudioControl {
-	precondition(objectID != kAudioObjectUnknown)
 	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectUnknown else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio control object ID")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/AudioControl.swift
+++ b/Sources/CAAudioHardware/AudioControl.swift
@@ -75,10 +75,6 @@ extension AudioObjectSelector where T == AudioControl {
 /// Creates and returns an initialized `AudioControl` or subclass.
 func makeAudioControl(_ objectID: AudioObjectID, baseClass: AudioClassID /*= kAudioControlClassID*/) throws -> AudioControl {
 	precondition(objectID != kAudioObjectSystemObject)
-	guard objectID != kAudioObjectUnknown else {
-		os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio control object ID")
-		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
-	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/AudioDevice.swift
+++ b/Sources/CAAudioHardware/AudioDevice.swift
@@ -1384,10 +1384,6 @@ extension AudioObjectSelector where T == AudioDevice {
 /// Creates and returns an initialized `AudioDevice` or subclass.
 func makeAudioDevice(_ objectID: AudioObjectID) throws -> AudioDevice {
 	precondition(objectID != kAudioObjectSystemObject)
-	guard objectID != kAudioObjectUnknown else {
-		os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio device object ID")
-		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
-	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/AudioDevice.swift
+++ b/Sources/CAAudioHardware/AudioDevice.swift
@@ -1395,8 +1395,11 @@ extension AudioObjectSelector where T == AudioDevice {
 
 /// Creates and returns an initialized `AudioDevice` or subclass.
 func makeAudioDevice(_ objectID: AudioObjectID) throws -> AudioDevice {
-	precondition(objectID != kAudioObjectUnknown)
 	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectUnknown else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio device object ID")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/AudioDevice.swift
+++ b/Sources/CAAudioHardware/AudioDevice.swift
@@ -21,38 +21,29 @@ public class AudioDevice: AudioClockDevice {
 		}
 	}
 
-	/// Returns the default input device or `nil` if unknown
+	/// Returns the default input device
 	/// - remark: This corresponds to the property`kAudioHardwarePropertyDefaultInputDevice` on `kAudioObjectSystemObject`
-	public static var defaultInputDevice: AudioDevice? {
+	public static var defaultInputDevice: AudioDevice {
 		get throws {
 			let objectID: AudioObjectID = try getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultInputDevice))
-			guard objectID != kAudioObjectUnknown else {
-				return nil
-			}
 			return try makeAudioDevice(objectID)
 		}
 	}
 
-	/// Returns the default output device or `nil` if unknown
+	/// Returns the default output device
 	/// - remark: This corresponds to the property`kAudioHardwarePropertyDefaultOutputDevice` on `kAudioObjectSystemObject`
-	public static var defaultOutputDevice: AudioDevice? {
+	public static var defaultOutputDevice: AudioDevice {
 		get throws {
 			let objectID: AudioObjectID = try getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultOutputDevice))
-			guard objectID != kAudioObjectUnknown else {
-				return nil
-			}
 			return try makeAudioDevice(objectID)
 		}
 	}
 
-	/// Returns the default system output device or `nil` if unknown
+	/// Returns the default system output device
 	/// - remark: This corresponds to the property`kAudioHardwarePropertyDefaultSystemOutputDevice` on `kAudioObjectSystemObject`
-	public static var defaultSystemOutputDevice: AudioDevice? {
+	public static var defaultSystemOutputDevice: AudioDevice {
 		get throws {
 			let objectID: AudioObjectID = try getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultSystemOutputDevice))
-			guard objectID != kAudioObjectUnknown else {
-				return nil
-			}
 			return try makeAudioDevice(objectID)
 		}
 	}

--- a/Sources/CAAudioHardware/AudioDevice.swift
+++ b/Sources/CAAudioHardware/AudioDevice.swift
@@ -25,8 +25,7 @@ public class AudioDevice: AudioClockDevice {
 	/// - remark: This corresponds to the property`kAudioHardwarePropertyDefaultInputDevice` on `kAudioObjectSystemObject`
 	public static var defaultInputDevice: AudioDevice {
 		get throws {
-			let objectID: AudioObjectID = try getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultInputDevice))
-			return try makeAudioDevice(objectID)
+			try makeAudioDevice(getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultInputDevice)))
 		}
 	}
 
@@ -34,8 +33,7 @@ public class AudioDevice: AudioClockDevice {
 	/// - remark: This corresponds to the property`kAudioHardwarePropertyDefaultOutputDevice` on `kAudioObjectSystemObject`
 	public static var defaultOutputDevice: AudioDevice {
 		get throws {
-			let objectID: AudioObjectID = try getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultOutputDevice))
-			return try makeAudioDevice(objectID)
+			try makeAudioDevice(getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultOutputDevice)))
 		}
 	}
 
@@ -43,8 +41,7 @@ public class AudioDevice: AudioClockDevice {
 	/// - remark: This corresponds to the property`kAudioHardwarePropertyDefaultSystemOutputDevice` on `kAudioObjectSystemObject`
 	public static var defaultSystemOutputDevice: AudioDevice {
 		get throws {
-			let objectID: AudioObjectID = try getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultSystemOutputDevice))
-			return try makeAudioDevice(objectID)
+			try makeAudioDevice(getPropertyData(objectID: .systemObject, property: PropertyAddress(kAudioHardwarePropertyDefaultSystemOutputDevice)))
 		}
 	}
 

--- a/Sources/CAAudioHardware/AudioDevice.swift
+++ b/Sources/CAAudioHardware/AudioDevice.swift
@@ -371,7 +371,7 @@ public class AudioDevice: AudioClockDevice {
 	/// - parameter scope: The desired scope
 	public func preferredStereoChannels(inScope scope: PropertyScope) throws -> (PropertyElement, PropertyElement) {
 		let channels = try getProperty(PropertyAddress(PropertySelector(kAudioDevicePropertyPreferredChannelsForStereo), scope: scope), elementType: UInt32.self)
-		precondition(channels.count == 2)
+		precondition(channels.count == 2, "Unexpected array length for kAudioDevicePropertyPreferredChannelsForStereo")
 		return (PropertyElement(channels[0]), PropertyElement(channels[1]))
 	}
 	/// Sets the preferred stereo channels
@@ -718,7 +718,7 @@ public class AudioDevice: AudioClockDevice {
 	/// - remark: This corresponds to the property `kAudioDevicePropertyStereoPanChannels`
 	public func stereoPanChannels(inScope scope: PropertyScope) throws -> (PropertyElement, PropertyElement) {
 		let channels = try getProperty(PropertyAddress(PropertySelector(kAudioDevicePropertyStereoPanChannels), scope: scope), elementType: UInt32.self)
-		precondition(channels.count == 2)
+		precondition(channels.count == 2, "Unexpected array length for kAudioDevicePropertyStereoPanChannels")
 		return (PropertyElement(channels[0]), PropertyElement(channels[1]))
 	}
 	/// Sets the channels used for stereo panning
@@ -971,7 +971,7 @@ public class AudioDevice: AudioClockDevice {
 	public var playThroughStereoPanChannels: (PropertyElement, PropertyElement) {
 		get throws {
 			let channels = try getProperty(PropertyAddress(PropertySelector(kAudioDevicePropertyPlayThruStereoPanChannels), scope: .playThrough), elementType: UInt32.self)
-			precondition(channels.count == 2)
+			precondition(channels.count == 2, "Unexpected array length for kAudioDevicePropertyPlayThruStereoPanChannels")
 			return (PropertyElement(channels[0]), PropertyElement(channels[1]))
 		}
 	}

--- a/Sources/CAAudioHardware/AudioObject.swift
+++ b/Sources/CAAudioHardware/AudioObject.swift
@@ -408,7 +408,7 @@ extension AudioObject {
 	/// - parameter objectID: The audio object ID
 	public static func make(_ objectID: AudioObjectID) throws -> AudioObject {
 		guard objectID != kAudioObjectUnknown else {
-			os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid AudioObjectID")
+			os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio object ID")
 			throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError), userInfo: nil)
 		}
 

--- a/Sources/CAAudioHardware/AudioObject.swift
+++ b/Sources/CAAudioHardware/AudioObject.swift
@@ -407,11 +407,6 @@ extension AudioObject {
 	/// Whenever possible this will return a specialized subclass exposing additional functionality
 	/// - parameter objectID: The audio object ID
 	public static func make(_ objectID: AudioObjectID) throws -> AudioObject {
-		guard objectID != kAudioObjectUnknown else {
-			os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio object ID")
-			throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
-		}
-
 		if objectID == kAudioObjectSystemObject {
 			return AudioSystem.instance
 		}
@@ -540,7 +535,6 @@ extension AudioObjectSelector: CustomStringConvertible {
 
 /// Creates and returns an initialized `AudioObject` or subclass.
 func makeAudioObject(_ objectID: AudioObjectID) throws -> AudioObject {
-	precondition(objectID != kAudioObjectUnknown)
 	precondition(objectID != kAudioObjectSystemObject)
 
 	let objectClass = try AudioObject.getClass(objectID)

--- a/Sources/CAAudioHardware/AudioPlugIn.swift
+++ b/Sources/CAAudioHardware/AudioPlugIn.swift
@@ -181,10 +181,6 @@ extension AudioObjectSelector where T == AudioPlugIn {
 /// Creates and returns an initialized `AudioPlugIn` or subclass.
 func makeAudioPlugIn(_ objectID: AudioObjectID) throws -> AudioPlugIn {
 	precondition(objectID != kAudioObjectSystemObject)
-	guard objectID != kAudioObjectUnknown else {
-		os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio plug-in object ID")
-		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
-	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/AudioPlugIn.swift
+++ b/Sources/CAAudioHardware/AudioPlugIn.swift
@@ -180,8 +180,11 @@ extension AudioObjectSelector where T == AudioPlugIn {
 
 /// Creates and returns an initialized `AudioPlugIn` or subclass.
 func makeAudioPlugIn(_ objectID: AudioObjectID) throws -> AudioPlugIn {
-	precondition(objectID != kAudioObjectUnknown)
 	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectUnknown else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectUnknown is not a valid audio plug-in object ID")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/BooleanControl.swift
+++ b/Sources/CAAudioHardware/BooleanControl.swift
@@ -114,7 +114,6 @@ public class ListenbackControl: BooleanControl {
 
 /// Creates and returns an initialized `BooleanControl` or subclass.
 func makeBooleanControl(_ objectID: AudioObjectID) throws -> BooleanControl {
-	precondition(objectID != kAudioObjectUnknown)
 	precondition(objectID != kAudioObjectSystemObject)
 
 	let objectClass = try AudioObject.getClass(objectID)

--- a/Sources/CAAudioHardware/LevelControl.swift
+++ b/Sources/CAAudioHardware/LevelControl.swift
@@ -123,7 +123,6 @@ public class LFEVolumeControl: LevelControl {
 
 /// Creates and returns an initialized `LevelControl` or subclass.
 func makeLevelControl(_ objectID: AudioObjectID) throws -> LevelControl {
-	precondition(objectID != kAudioObjectUnknown)
 	precondition(objectID != kAudioObjectSystemObject)
 
 	let objectClass = try AudioObject.getClass(objectID)

--- a/Sources/CAAudioHardware/SelectorControl.swift
+++ b/Sources/CAAudioHardware/SelectorControl.swift
@@ -120,7 +120,6 @@ public class HighPassFilterControl: SelectorControl {
 
 /// Creates and returns an initialized `SelectorControl` or subclass.
 func makeSelectorControl(_ objectID: AudioObjectID) throws -> SelectorControl {
-	precondition(objectID != kAudioObjectUnknown)
 	precondition(objectID != kAudioObjectSystemObject)
 
 	let objectClass = try AudioObject.getClass(objectID)

--- a/Sources/CAAudioHardware/StereoPanControl.swift
+++ b/Sources/CAAudioHardware/StereoPanControl.swift
@@ -28,7 +28,7 @@ public class StereoPanControl: AudioControl {
 	public var panningChannels: (PropertyElement, PropertyElement) {
 		get throws {
 			let channels = try getProperty(PropertyAddress(kAudioStereoPanControlPropertyPanningChannels), elementType: UInt32.self)
-			precondition(channels.count == 2)
+			precondition(channels.count == 2, "Unexpected array length for kAudioStereoPanControlPropertyPanningChannels")
 			return (PropertyElement(channels[0]), PropertyElement(channels[1]))
 		}
 	}

--- a/Tests/CAAudioHardwareTests/CAAudioHardwareTests.swift
+++ b/Tests/CAAudioHardwareTests/CAAudioHardwareTests.swift
@@ -1,7 +1,12 @@
 import XCTest
+import CoreAudio
 @testable import CAAudioHardware
 
 final class CAAudioHardwareTests: XCTestCase {
+	func testObject() {
+		XCTAssertThrowsError(try AudioObject.make(kAudioObjectUnknown))
+	}
+
 	func testDevices() throws {
 		let devices = try AudioDevice.devices
 		for device in devices {


### PR DESCRIPTION
Throw an error instead of crashing since sometimes `kAudioObjectUnknown` is unavoidable.

Also changes the return type for default device getters to non-optional since they now throw for `kAudioObjectUnknown`.