### PR TITLE
Relax preconditions on `kAudioObjectSystemObject`

### DIFF
--- a/Sources/CAAudioHardware/AudioControl.swift
+++ b/Sources/CAAudioHardware/AudioControl.swift
@@ -74,7 +74,10 @@ extension AudioObjectSelector where T == AudioControl {
 
 /// Creates and returns an initialized `AudioControl` or subclass.
 func makeAudioControl(_ objectID: AudioObjectID, baseClass: AudioClassID /*= kAudioControlClassID*/) throws -> AudioControl {
-	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectSystemObject else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectSystemObject is not a valid audio control object id")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/AudioDevice.swift
+++ b/Sources/CAAudioHardware/AudioDevice.swift
@@ -1383,7 +1383,10 @@ extension AudioObjectSelector where T == AudioDevice {
 
 /// Creates and returns an initialized `AudioDevice` or subclass.
 func makeAudioDevice(_ objectID: AudioObjectID) throws -> AudioDevice {
-	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectSystemObject else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectSystemObject is not a valid audio device object id")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/AudioPlugIn.swift
+++ b/Sources/CAAudioHardware/AudioPlugIn.swift
@@ -180,7 +180,10 @@ extension AudioObjectSelector where T == AudioPlugIn {
 
 /// Creates and returns an initialized `AudioPlugIn` or subclass.
 func makeAudioPlugIn(_ objectID: AudioObjectID) throws -> AudioPlugIn {
-	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectSystemObject else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectSystemObject is not a valid audio plug-in object id")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/BooleanControl.swift
+++ b/Sources/CAAudioHardware/BooleanControl.swift
@@ -114,7 +114,10 @@ public class ListenbackControl: BooleanControl {
 
 /// Creates and returns an initialized `BooleanControl` or subclass.
 func makeBooleanControl(_ objectID: AudioObjectID) throws -> BooleanControl {
-	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectSystemObject else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectSystemObject is not a valid boolean control object id")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/LevelControl.swift
+++ b/Sources/CAAudioHardware/LevelControl.swift
@@ -123,7 +123,10 @@ public class LFEVolumeControl: LevelControl {
 
 /// Creates and returns an initialized `LevelControl` or subclass.
 func makeLevelControl(_ objectID: AudioObjectID) throws -> LevelControl {
-	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectSystemObject else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectSystemObject is not a valid level control object id")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 

--- a/Sources/CAAudioHardware/SelectorControl.swift
+++ b/Sources/CAAudioHardware/SelectorControl.swift
@@ -120,7 +120,10 @@ public class HighPassFilterControl: SelectorControl {
 
 /// Creates and returns an initialized `SelectorControl` or subclass.
 func makeSelectorControl(_ objectID: AudioObjectID) throws -> SelectorControl {
-	precondition(objectID != kAudioObjectSystemObject)
+	guard objectID != kAudioObjectSystemObject else {
+		os_log(.error, log: audioObjectLog, "kAudioObjectSystemObject is not a valid selector control object id")
+		throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioHardwareBadObjectError))
+	}
 
 	let objectClass = try AudioObject.getClass(objectID)
 


### PR DESCRIPTION
It's unclear how or why the precondition would fail, but it's possible (#68). This replaces the precondition with an error.